### PR TITLE
feat: Add conventional commit title checks, not post with no errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,27 @@ jobs:
           enforce_draft: 'false'
           require_milestone: 'true'
           custom_error_messages: '{"title_too_short": "Please provide a more descriptive title."}'
+          comment_with_no_errors: 'true'
+          require_conventional_commit_title: 'false'
 ```
 
 ## Inputs
 
-| Input                            | Description                                                        | Required | Default               |
-| -------------------------------- | ------------------------------------------------------------------ | -------- | --------------------- |
-| `github_token`                   | GitHub token for posting comments to PR thread                     | No       | `${{ github.token }}` |
-| `require_description_min_length` | Minimum length of the PR description                               | No       | `0`                   |
-| `require_title_min_length`       | Minimum length of the PR title                                     | No       | `10`                  |
-| `required_labels_any`            | Any of these labels must be present on the PR (comma-separated)    | No       | -                     |
-| `required_labels_all`            | All of these labels must be present on the PR (comma-separated)    | No       | -                     |
-| `banned_labels`                  | None of these labels should be present on the PR (comma-separated) | No       | -                     |
-| `require_assignee`               | Whether to require at least one assignee                           | No       | `false`               |
-| `enforce_draft`                  | Whether to enforce non-draft pull requests                         | No       | `false`               |
-| `required_issue_types`           | PR must include one of these issue types (comma-separated)         | No       | -                     |
-| `require_milestone`              | Whether to require a milestone on the PR                           | No       | `false`               |
-| `custom_error_messages`          | JSON object with custom error messages for various checks          | No       | -                     |
+| Input                               | Description                                                        | Required | Default               |
+| ----------------------------------- | ------------------------------------------------------------------ | -------- | --------------------- |
+| `github_token`                      | GitHub token for posting comments to PR thread                     | No       | `${{ github.token }}` |
+| `require_description_min_length`    | Minimum length of the PR description                               | No       | `0`                   |
+| `require_title_min_length`          | Minimum length of the PR title                                     | No       | `10`                  |
+| `required_labels_any`               | Any of these labels must be present on the PR (comma-separated)    | No       | -                     |
+| `required_labels_all`               | All of these labels must be present on the PR (comma-separated)    | No       | -                     |
+| `banned_labels`                     | None of these labels should be present on the PR (comma-separated) | No       | -                     |
+| `require_assignee`                  | Whether to require at least one assignee                           | No       | `false`               |
+| `enforce_draft`                     | Whether to enforce non-draft pull requests                         | No       | `false`               |
+| `required_issue_types`              | PR must include one of these issue types (comma-separated)         | No       | -                     |
+| `require_milestone`                 | Whether to require a milestone on the PR                           | No       | `false`               |
+| `custom_error_messages`             | JSON object with custom error messages for various checks          | No       | -                     |
+| `comment_with_no_errors`            | Whether to post a comment on the PR when there are no errors       | No       | `true`                |
+| `require_conventional_commit_title` | Whether to validate the PR title starts like a conventional commit | No       | `false`               |
 
 ## Issue Type Enforcement
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,14 @@ inputs:
     description: 'GitHub token for posting comments to PR thread'
     required: false
     default: '${{ github.token }}'
+  comment_with_no_errors:
+    description: 'Whether to post a comment when no errors are found'
+    required: false
+    default: 'true'
+  require_conventional_commit_title:
+    description: 'Whether to require the pull request title to follow conventional commit format'
+    required: false
+    default: 'false'
 
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -30008,6 +30008,11 @@ async function postReportToPullRequest(errors, successes) {
             core.warning('Could not find pull request number in context. Unable to post comments.');
             return;
         }
+        const commentWithNoErrors = core.getInput('comment_with_no_errors') === 'true';
+        if (!commentWithNoErrors && errors.length == 0) {
+            core.info('No errors found. No need to post a comment.');
+            return;
+        }
         const prNumber = context.payload.pull_request.number;
         // Format the comment message
         let statusHeader = errors.length > 0
@@ -30071,6 +30076,18 @@ async function postReportToPullRequest(errors, successes) {
     }
 }
 function checkTitle(pullRequest) {
+    const checkConventionalCommitTitle = core.getInput('require_conventional_commit_title') === 'true';
+    if (checkConventionalCommitTitle) {
+        const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|perf|test|chore|release)(\([a-z-]+\))?: .+/;
+        if (!conventionalCommitPattern.test(pullRequest.title)) {
+            const errorMsg = getCustomErrorMessage('invalid_title_format') ||
+                'Pull request title must follow the conventional commit format: "type(scope): description".';
+            errorMessages.push(errorMsg);
+        }
+        else {
+            successMessages.push('Title follows conventional commit format');
+        }
+    }
     const minLength = parseInt(core.getInput('require_title_min_length'), 10);
     if (minLength) {
         if (pullRequest.title.length < minLength) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pulls-with-spice-action",
-    "version": "1.0.6",
+    "version": "1.0.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pulls-with-spice-action",
-            "version": "1.0.6",
+            "version": "1.0.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pulls-with-spice-action",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "GitHub Action to enforce standards for pull requests with extra spice",
     "main": "dist/index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,12 @@ async function postReportToPullRequest(
       return;
     }
 
+    const commentWithNoErrors = core.getInput('comment_with_no_errors') === 'true';
+    if (!commentWithNoErrors && errors.length == 0) {
+      core.info('No errors found. No need to post a comment.');
+      return;
+    }
+
     const prNumber = context.payload.pull_request.number;
 
     // Format the comment message
@@ -174,6 +180,19 @@ async function postReportToPullRequest(
 }
 
 function checkTitle(pullRequest: ContentObject): void {
+  const checkConventionalCommitTitle = core.getInput('require_conventional_commit_title') === 'true';
+  if (checkConventionalCommitTitle) {
+    const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|perf|test|chore|release)(\([a-z-]+\))?: .+/;
+    if (!conventionalCommitPattern.test(pullRequest.title)) {
+      const errorMsg =
+        getCustomErrorMessage('invalid_title_format') ||
+        'Pull request title must follow the conventional commit format: "type(scope): description".';
+      errorMessages.push(errorMsg);
+    } else {
+      successMessages.push('Title follows conventional commit format');
+    }
+  }
+
   const minLength = parseInt(core.getInput('require_title_min_length'), 10);
   if (minLength) {
     if (pullRequest.title.length < minLength) {


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds an optional to check that PR titles start with conventional commit messages
* Adds an option to not post a comment when there are no validation errors