### PR TITLE
feat: drop size labelling, now that GitHub applies size labels natively

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -21,5 +21,4 @@ jobs:
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           require_assignee: 'true'
           auto_label: 'true'
-          auto_label_size: 'true'
           auto_label_type: 'true'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ A GitHub Action that enforces standards for pull requests with extra flavor.
   - Changed file paths
   - PR title patterns (conventional commit types)
   - PR description patterns
-  - PR size (lines changed)
 - **Auto-assignment**: Automatically assign PR authors or specific users
 - **Smart Comments**: Post detailed status reports with suggested fixes
 - **Customizable Messages**: Provide custom error messages for any check
@@ -46,7 +45,6 @@ jobs:
         with:
           # Enable only what you need - all checks are off by default
           auto_label: 'true'
-          auto_label_size: 'true'
           auto_assign_author: 'true'
 ```
 
@@ -71,7 +69,6 @@ jobs:
     branch_name_pattern: '^(feature|fix|docs|chore)/.*'
     # Automation features
     auto_label: 'true'
-    auto_label_size: 'true'
     auto_label_type: 'true'
     auto_assign: 'true'
     auto_assign_author: 'true'
@@ -94,7 +91,6 @@ jobs:
 | `require_milestone`              | Require a milestone on the PR                            | No       | `false`               |
 | `branch_name_pattern`            | Regex pattern that branch names must match               | No       | -                     |
 | `auto_label`                     | Enable automatic labeling based on file paths            | No       | `false`               |
-| `auto_label_size`                | Add size labels based on lines changed                   | No       | `false`               |
 | `auto_label_type`                | Add type labels based on conventional commit prefix      | No       | `false`               |
 | `auto_assign`                    | Enable automatic assignment                              | No       | `false`               |
 | `auto_assign_author`             | Assign the PR author automatically                       | No       | `false`               |
@@ -124,18 +120,6 @@ When `auto_label` is enabled, the action automatically applies labels based on:
 | `area/tests`        | Files in `test/`, `tests/`, `__tests__/`, `spec/`               |
 | `area/config`       | Config files: `.json`, `.yaml`, `.yml`, `.toml`, `.ini`, `.env` |
 | `kind/dependencies` | Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, etc.    |
-
-### Size Labels
-
-When `auto_label_size` is enabled, PRs get labeled based on total lines changed:
-
-| Label     | Lines Changed |
-| --------- | ------------- |
-| `size/xs` | ≤ 10          |
-| `size/s`  | 11-50         |
-| `size/m`  | 51-200        |
-| `size/l`  | 201-500       |
-| `size/xl` | > 500         |
 
 ### Type Labels from Conventional Commits
 

--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,6 @@ inputs:
     description: 'Enable automatic labeling based on file paths and conventional commits'
     required: false
     default: 'false'
-  auto_label_size:
-    description: 'Automatically add size labels (size/xs, size/s, size/m, size/l, size/xl) based on changes'
-    required: false
-    default: 'false'
   auto_label_type:
     description: 'Automatically add type labels based on conventional commit prefixes in title'
     required: false

--- a/dist/index.d.ts.map
+++ b/dist/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"","sourceRoot":"","sources":["file:///home/lukim/dev/pulls-with-spice-action/src/index.ts"],"names":[],"mappings":""}
+{"version":3,"file":"","sourceRoot":"","sources":["file:///Users/lukim/dev/pulls-with-spice-action.worktrees/drop-size-labels/src/index.ts"],"names":[],"mappings":""}

--- a/dist/index.js
+++ b/dist/index.js
@@ -30277,12 +30277,9 @@ async function run() {
         const octokit = token ? github.getOctokit(token) : null;
         // Determine which features need file data (optimization: only fetch if needed)
         const autoLabelEnabled = core.getInput('auto_label') === 'true';
-        const autoLabelSizeEnabled = core.getInput('auto_label_size') === 'true';
         // Get changed files for auto-labeling (if enabled)
         let changedFiles = [];
-        if (octokit &&
-            pullRequest.number &&
-            (autoLabelEnabled || autoLabelSizeEnabled)) {
+        if (octokit && pullRequest.number && autoLabelEnabled) {
             changedFiles = await getChangedFiles(octokit, pullRequest.number);
         }
         // Auto-labeling (runs before validation)
@@ -30621,9 +30618,8 @@ async function getChangedFiles(octokit, prNumber) {
 }
 async function performAutoLabeling(octokit, pullRequest, changedFiles) {
     const autoLabelEnabled = core.getInput('auto_label') === 'true';
-    const autoLabelSizeEnabled = core.getInput('auto_label_size') === 'true';
     const autoLabelTypeEnabled = core.getInput('auto_label_type') === 'true';
-    if (!autoLabelEnabled && !autoLabelSizeEnabled && !autoLabelTypeEnabled) {
+    if (!autoLabelEnabled && !autoLabelTypeEnabled) {
         return;
     }
     const labelsToAdd = new Set();
@@ -30669,19 +30665,6 @@ async function performAutoLabeling(octokit, pullRequest, changedFiles) {
             }
         }
     }
-    // Size-based labeling
-    if (autoLabelSizeEnabled && changedFiles.length > 0) {
-        const totalChanges = changedFiles.reduce((sum, file) => sum + file.additions + file.deletions, 0);
-        const sizeLabel = getSizeLabel(totalChanges);
-        if (sizeLabel) {
-            // Remove any existing size labels from our set
-            const sizeLabels = ['size/xs', 'size/s', 'size/m', 'size/l', 'size/xl'];
-            for (const sl of sizeLabels) {
-                labelsToAdd.delete(sl);
-            }
-            labelsToAdd.add(sizeLabel);
-        }
-    }
     // Conventional commit type-based labeling
     if (autoLabelTypeEnabled) {
         const typeLabel = getTypeLabelFromTitle(pullRequest.title);
@@ -30705,17 +30688,6 @@ async function performAutoLabeling(octokit, pullRequest, changedFiles) {
             core.warning(`Failed to apply labels: ${error}`);
         }
     }
-}
-function getSizeLabel(totalChanges) {
-    if (totalChanges <= 10)
-        return 'size/xs';
-    if (totalChanges <= 50)
-        return 'size/s';
-    if (totalChanges <= 200)
-        return 'size/m';
-    if (totalChanges <= 500)
-        return 'size/l';
-    return 'size/xl';
 }
 function getTypeLabelFromTitle(title) {
     const conventionalCommitRegex = /^(\w+)(?:\([^)]+\))?!?:/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,15 +96,10 @@ async function run(): Promise<void> {
 
     // Determine which features need file data (optimization: only fetch if needed)
     const autoLabelEnabled = core.getInput('auto_label') === 'true';
-    const autoLabelSizeEnabled = core.getInput('auto_label_size') === 'true';
 
     // Get changed files for auto-labeling (if enabled)
     let changedFiles: ChangedFile[] = [];
-    if (
-      octokit &&
-      pullRequest.number &&
-      (autoLabelEnabled || autoLabelSizeEnabled)
-    ) {
+    if (octokit && pullRequest.number && autoLabelEnabled) {
       changedFiles = await getChangedFiles(octokit, pullRequest.number);
     }
 
@@ -528,10 +523,9 @@ async function performAutoLabeling(
   changedFiles: ChangedFile[]
 ): Promise<void> {
   const autoLabelEnabled = core.getInput('auto_label') === 'true';
-  const autoLabelSizeEnabled = core.getInput('auto_label_size') === 'true';
   const autoLabelTypeEnabled = core.getInput('auto_label_type') === 'true';
 
-  if (!autoLabelEnabled && !autoLabelSizeEnabled && !autoLabelTypeEnabled) {
+  if (!autoLabelEnabled && !autoLabelTypeEnabled) {
     return;
   }
 
@@ -581,23 +575,6 @@ async function performAutoLabeling(
     }
   }
 
-  // Size-based labeling
-  if (autoLabelSizeEnabled && changedFiles.length > 0) {
-    const totalChanges = changedFiles.reduce(
-      (sum, file) => sum + file.additions + file.deletions,
-      0
-    );
-    const sizeLabel = getSizeLabel(totalChanges);
-    if (sizeLabel) {
-      // Remove any existing size labels from our set
-      const sizeLabels = ['size/xs', 'size/s', 'size/m', 'size/l', 'size/xl'];
-      for (const sl of sizeLabels) {
-        labelsToAdd.delete(sl);
-      }
-      labelsToAdd.add(sizeLabel);
-    }
-  }
-
   // Conventional commit type-based labeling
   if (autoLabelTypeEnabled) {
     const typeLabel = getTypeLabelFromTitle(pullRequest.title);
@@ -624,14 +601,6 @@ async function performAutoLabeling(
       core.warning(`Failed to apply labels: ${error}`);
     }
   }
-}
-
-function getSizeLabel(totalChanges: number): string {
-  if (totalChanges <= 10) return 'size/xs';
-  if (totalChanges <= 50) return 'size/s';
-  if (totalChanges <= 200) return 'size/m';
-  if (totalChanges <= 500) return 'size/l';
-  return 'size/xl';
 }
 
 function getTypeLabelFromTitle(title: string): string | null {


### PR DESCRIPTION
GitHub labels pull requests by size itself now, so the action doing it too means two labellers writing to the same `size/*` namespace on the same PR — the second one to run wins, and neither is authoritative.

## What changes

- `action.yml` — the `auto_label_size` input is gone.
- `src/index.ts` — the size-labelling block, the `size/xs…size/xl` thresholds (`getSizeLabel`), and both `auto_label_size` reads. The changed-file fetch is now gated on `auto_label` alone: size labelling was its only other caller, so a PR with only type labelling enabled stops paying for a files API call it never used.
- `README.md` — the input row, the "Size Labels" threshold table, the feature bullet, and the two examples that passed it.
- This repo's own `enforce-pulls-with-spice.yml` stops passing it.
- `dist/` is rebuilt. It is committed here and consumers pin a SHA, so a source-only change would land as a no-op for every one of them.

`auto_label` (path-based) and `auto_label_type` (conventional-commit) labelling are untouched.

## Upgrade impact

None mechanically. An input an action does not declare is a warning, not an error, so a consumer still passing `auto_label_size: 'true'` keeps working — it just stops applying the labels. The one consumer I know of, `spiceai/spiceai`, drops the input in spiceai/spiceai#12373.

## Testing

`npm run lint` and `npm run build` are clean. The rebuilt bundle differs from the committed one by exactly this change (32 lines out of 1.1 MB), which also confirms `dist/` regenerates reproducibly from the current lockfile.

Repo-wide `prettier --check` reports `src/index.ts`, `action.yml` and `README.md` as unformatted — that predates this branch (the same three fail at `trunk`), so I left it alone rather than mixing a whole-file reformat into this diff.

## Follow-up

After merge this needs a release for the major tag and any SHA pins to pick it up.