### PR TITLE
fix: pin @actions/github to v7, which the CJS bundle can resolve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^2.0.2",
-                "@actions/github": "^9.0.0"
+                "@actions/github": "^7.0.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.5.14",
@@ -45,18 +45,30 @@
             }
         },
         "node_modules/@actions/github": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.0.0.tgz",
-            "integrity": "sha512-yJ0RoswsAaKcvkmpCE4XxBRiy/whH2SdTBHWzs0gi4wkqTDhXMChjSdqBz/F4AeiDlP28rQqL33iHb+kjAMX6w==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-7.0.0.tgz",
+            "integrity": "sha512-PyGODO938aoBTZd/IfN/+e+Pd5hUcVpyf+thm4CPESLeqhdSkq5QwMTGX9v84XHE1ifmHWBQ60KB8kIgm96opw==",
             "license": "MIT",
             "dependencies": {
-                "@actions/http-client": "^3.0.2",
-                "@octokit/core": "^7.0.6",
-                "@octokit/plugin-paginate-rest": "^14.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
-                "@octokit/request": "^10.0.7",
-                "@octokit/request-error": "^7.1.0",
-                "undici": "^6.23.0"
+                "@actions/http-client": "^3.0.1",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.2.2",
+                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "undici": "^5.28.5"
+            }
+        },
+        "node_modules/@actions/github/node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
             }
         },
         "node_modules/@actions/http-client": {
@@ -692,6 +704,15 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1255,131 +1276,161 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
             "license": "MIT",
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/auth-token": "^6.0.0",
-                "@octokit/graphql": "^9.0.3",
-                "@octokit/request": "^10.0.6",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "before-after-hook": "^4.0.0",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^10.0.6",
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "27.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
             "license": "MIT"
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^16.0.0"
+                "@octokit/types": "^12.6.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^16.0.0"
+                "@octokit/types": "^12.6.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "10.0.8",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-            "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/endpoint": "^11.0.3",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "fast-content-type-parse": "^3.0.0",
-                "json-with-bigint": "^3.5.3",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^16.0.0"
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
             },
             "engines": {
-                "node": ">= 20"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^27.0.0"
+                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -2053,9 +2104,9 @@
             "license": "MIT"
         },
         "node_modules/before-after-hook": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
             "license": "Apache-2.0"
         },
         "node_modules/brace-expansion": {
@@ -2388,6 +2439,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "license": "ISC"
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
@@ -2736,22 +2793,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/fast-content-type-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-            "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -4026,12 +4067,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-with-bigint": {
-            "version": "3.5.8",
-            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
-            "license": "MIT"
-        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4271,7 +4306,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -5248,9 +5282,9 @@
             "license": "MIT"
         },
         "node_modules/universal-user-agent": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
             "license": "ISC"
         },
         "node_modules/update-browserslist-db": {
@@ -5367,7 +5401,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@actions/core": "^2.0.2",
-        "@actions/github": "^9.0.0"
+        "@actions/github": "^7.0.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.14",


### PR DESCRIPTION
`npm run build` currently fails on a clean `trunk` checkout:

```
Error: Module not found: Error: Package path . is not exported from package node_modules/@actions/github
```

`@actions/github` v9 ships an exports map with only `types` and `import` conditions — no `require`:

```json
"exports": { ".": { "types": "./lib/github.d.ts", "import": "./lib/github.js" } }
```

This action bundles as **CommonJS** (`ncc build … into CJS`, and `action.yml` runs `node24` against `dist/index.js`), so the v7 → v9 bump in a5fe361 broke every build from trunk — including the one the **release workflow** runs against a tag, which is how `dist/` gets published.

## The fix

Pin back to `^7.0.0`, the last release with a `require` condition, and revert the octokit tree that came with it. Nothing in `src/` touches a v9 API, so this is a dependency change only: `package.json` one line, `package-lock.json` regenerated.

`dist/` is deliberately **not** rebuilt here. It is a self-contained bundle that still runs, this PR is about restoring the ability to build, and the release workflow rebuilds `dist` on the tag anyway.

## Testing

`npm ci && npm run build` on this branch produces the bundle (2041 kB); `npm run lint` is clean. Both fail / are unreachable on `trunk` as it stands.

## Follow-up

Adopting v9 properly means emitting an ESM bundle — ncc flags, the `action.yml` runtime declaration, and every import — worth doing deliberately rather than inside a build fix. Until then, a dependabot PR that bumps `@actions/github` past v7 should be expected to fail this way; the repo has no build check on PRs to catch it (only `enforce-pull-with-spice`), which is arguably the deeper gap.