### PR TITLE
chore: prepare v3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. v2.1.0'
+        description: 'Version to release, e.g. v3.1.0'
         required: true
         type: string
       prerelease:
@@ -91,8 +91,8 @@ jobs:
           git tag -a "$VERSION" -m "$VERSION"
           git push origin "refs/tags/$VERSION"
 
-          # The major tag floats by design — `@v2` is meant to follow the newest v2.
-          # Prereleases are excluded so `@v2` never points at one.
+          # The major tag floats by design — `@v3` is meant to follow the newest v3.
+          # Prereleases are excluded so `@v3` never points at one.
           if [[ "$IS_PRERELEASE" == "true" ]]; then
             echo "Prerelease $VERSION: leaving the major tag where it is."
           elif [[ "$VERSION" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. v3.1.0'
+        description: 'Version to release, e.g. v3.0.0'
         required: true
         type: string
       prerelease:

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ to OpenAI, with `spice_cloud_region` ignored. Give `ai_model` a bare OpenAI mode
 ## Releasing
 
 `dist/` is not committed to the branch — it is built onto the tag. Release by running
-the **Release** workflow (`workflow_dispatch`) with the version, e.g. `v3.1.0`:
+the **Release** workflow (`workflow_dispatch`) with the version, e.g. `v3.0.0`:
 
 1. Lints, typechecks and builds the bundle, then runs it to confirm it loads.
 2. Commits `dist/` as a child of the released source commit and creates the version tag

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ A GitHub Action that enforces standards for pull requests with extra flavor.
 - **Smart Comments**: Post detailed status reports with suggested fixes
 - **Customizable Messages**: Provide custom error messages for any check
 
+## Upgrading from v2
+
+Point your workflow at `@v3` and check one input:
+
+- **`auto_label_size` is gone.** GitHub applies size labels natively now, so the action
+  no longer does. Remove the input — an unrecognized input is only a warning, but leaving
+  it implies a behaviour you are no longer getting. Existing `size/*` labels are left
+  alone; the action simply stops adding them.
+
+Everything else is additive. `auto_assign_author` now works without `auto_assign`, which
+previously left it silently doing nothing, and the new AI, native-type and priority
+inputs are all opt-in and default to off.
+
 ## Quick Start
 
 Create a workflow file (e.g., `.github/workflows/pulls-with-spice.yml`) in your repository:
@@ -42,7 +55,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: spiceai/pulls-with-spice-action@v2
+      - uses: spiceai/pulls-with-spice-action@v3
         with:
           # Enable only what you need - all checks are off by default
           auto_label: 'true'
@@ -52,7 +65,7 @@ jobs:
 ## Full Configuration Example
 
 ```yaml
-- uses: spiceai/pulls-with-spice-action@v2
+- uses: spiceai/pulls-with-spice-action@v3
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     # Title and description requirements
@@ -113,7 +126,7 @@ priority no longer have to be encoded in labels like `kind/bug` or `priority/p1`
 inputs enforce the native fields directly:
 
 ```yaml
-- uses: spiceai/pulls-with-spice-action@v2
+- uses: spiceai/pulls-with-spice-action@v3
   with:
     require_issue_type: 'true'
     allowed_issue_types: 'Bug,Feature,Task'
@@ -211,7 +224,7 @@ description, changed files, current labels and the repository's full label list 
 model, and applies the additions and removals the model returns.
 
 ```yaml
-- uses: spiceai/pulls-with-spice-action@v2
+- uses: spiceai/pulls-with-spice-action@v3
   with:
     spice_api_key: ${{ secrets.SPICE_API_KEY }}
     ai_auto_label: 'true'
@@ -270,7 +283,7 @@ A `spice_api_key` beginning with `sk-` is treated as an OpenAI API key and sent 
 to OpenAI, with `spice_cloud_region` ignored. Give `ai_model` a bare OpenAI model name:
 
 ```yaml
-- uses: spiceai/pulls-with-spice-action@v2
+- uses: spiceai/pulls-with-spice-action@v3
   with:
     spice_api_key: ${{ secrets.OPENAI_API_KEY }}
     ai_auto_label: 'true'
@@ -280,7 +293,7 @@ to OpenAI, with `spice_cloud_region` ignored. Give `ai_model` a bare OpenAI mode
 ## Releasing
 
 `dist/` is not committed to the branch — it is built onto the tag. Release by running
-the **Release** workflow (`workflow_dispatch`) with the version, e.g. `v2.1.0`:
+the **Release** workflow (`workflow_dispatch`) with the version, e.g. `v3.1.0`:
 
 1. Lints, typechecks and builds the bundle, then runs it to confirm it loads.
 2. Commits `dist/` as a child of the released source commit and creates the version tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pulls-with-spice-action",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pulls-with-spice-action",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^3.0.1",
@@ -26,7 +26,7 @@
                 "jest": "^30.4.2",
                 "prettier": "^3.9.6",
                 "ts-jest": "^29.4.12",
-                "typescript": "^7.0.2"
+                "typescript": "^6.0.3"
             }
         },
         "node_modules/@actions/core": {
@@ -2699,346 +2699,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript/typescript-aix-ppc64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-darwin-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-darwin-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-freebsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-freebsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-arm": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-loong64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-mips64el": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-ppc64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-riscv64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-s390x": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-linux-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-netbsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-netbsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-openbsd-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-openbsd-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-sunos-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-win32-arm64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@typescript/typescript-win32-x64": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=16.20.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -6873,38 +6533,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
-                "tsc": "bin/tsc"
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=16.20.0"
-            },
-            "optionalDependencies": {
-                "@typescript/typescript-aix-ppc64": "7.0.2",
-                "@typescript/typescript-darwin-arm64": "7.0.2",
-                "@typescript/typescript-darwin-x64": "7.0.2",
-                "@typescript/typescript-freebsd-arm64": "7.0.2",
-                "@typescript/typescript-freebsd-x64": "7.0.2",
-                "@typescript/typescript-linux-arm": "7.0.2",
-                "@typescript/typescript-linux-arm64": "7.0.2",
-                "@typescript/typescript-linux-loong64": "7.0.2",
-                "@typescript/typescript-linux-mips64el": "7.0.2",
-                "@typescript/typescript-linux-ppc64": "7.0.2",
-                "@typescript/typescript-linux-riscv64": "7.0.2",
-                "@typescript/typescript-linux-s390x": "7.0.2",
-                "@typescript/typescript-linux-x64": "7.0.2",
-                "@typescript/typescript-netbsd-arm64": "7.0.2",
-                "@typescript/typescript-netbsd-x64": "7.0.2",
-                "@typescript/typescript-openbsd-arm64": "7.0.2",
-                "@typescript/typescript-openbsd-x64": "7.0.2",
-                "@typescript/typescript-sunos-x64": "7.0.2",
-                "@typescript/typescript-win32-arm64": "7.0.2",
-                "@typescript/typescript-win32-x64": "7.0.2"
+                "node": ">=14.17"
             }
         },
         "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
         "jest": "^30.4.2",
         "prettier": "^3.9.6",
         "ts-jest": "^29.4.12",
-        "typescript": "^7.0.2"
+        "typescript": "^6.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "pulls-with-spice-action",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "description": "GitHub Action to enforce standards for pull requests with extra spice",
     "main": "dist/index.js",
     "scripts": {
-        "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js --sourcemap",
+        "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js",
         "format": "prettier --write **/*.ts",
         "format-check": "prettier --check **/*.ts",
         "lint": "eslint src/**/*.ts",


### PR DESCRIPTION
Release prep for the first v3.

## Why major

`auto_label_size` was removed from the action's inputs after v2.0.0 — GitHub applies size labels natively now. An unrecognized Action input only warns rather than failing, so nothing breaks outright, but a config that still sets it quietly stops getting the behaviour it asks for. Combined with AI auto-labelling being a substantial new capability, that reads as a major rather than something to bury in a minor.

## Changes

- `package.json` → `3.0.0`
- New **Upgrading from v2** section naming the one input that changed
- Every usage example points at `@v3`
- Drops `--sourcemap` from the build

The sourcemap mattered because the release workflow commits `dist/` onto each tag, making it 4.4MB of dead weight per release: Node reads it only under `--enable-source-maps`, and a `runs.using: node24` action has no way to pass node flags.

## Worth knowing before releasing

**No `v2` tag was ever created.** The tag list goes `v1`, `v1.0`, `v1.0.1`…`v1.0.7`, `v2.0.0` — so the `@v2` these examples used to name has never resolved for anyone who copied them. `v3` will be the first floating major tag since `v1`.

Two follow-ups that are yours to call:

1. Whether to also create `v2` pointing at `v2.0.0`, so anyone who followed the README since January isn't left broken.
2. The release workflow rewritten in #9 has never run. I simulated every step locally against trunk — version validation, tag-collision check, `npm ci`, lint, typecheck, build, the bundle smoke test, and `git add -f dist/` staging correctly against the ignore rule — all pass. The parts I can't rehearse locally are the tag push and `gh release create`.