### PR TITLE
fix: evaluate the pull request as it is now, not as the payload froze it (fixes spiceai/spiceai#12805)

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -40,6 +40,8 @@ jobs:
       # would catch a type error in src/.
       - run: npm run typecheck
         if: github.event_name == 'pull_request'
+      - run: npm test
+        if: github.event_name == 'pull_request'
       # dist/ is not committed; it is built here and on release.
       - run: npm run build
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ concurrency:
 Keep the `labeled`/`unlabeled` triggers — they are what re-runs the check when someone
 adds the missing label — and let `concurrency` collapse the redundant runs.
 
+### Re-running a run
+
+The checks read the pull request or issue from the API when the run starts, not from the
+event payload. This matters because a payload is a snapshot frozen when the run was
+created, and re-running a workflow replays that snapshot: a gate reading it would report
+the labels, assignees, title and draft state as they were then, so re-running a failed
+check could only ever reproduce the failure, never observe the fix that discharged it.
+
+So **re-running this check re-evaluates the subject as it is now**, and a run that starts
+moments after a pull request is opened sees an assignee or label applied in between.
+
+Reading it needs a token with `pull-requests: read` (the default `github.token` under
+`permissions: pull-requests: write` is enough). Without one, or if the read fails, the
+action warns and falls back to the payload rather than failing the check — an API blip
+should not turn a required check red.
+
 ## Label Prefixes
 
 The `required_label_prefixes` input requires at least one label from each specified prefix category:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,15 @@
+/**
+ * The action's dependencies — `@actions/core`, `@actions/github`, `ai` — publish ESM only, with
+ * no `require` condition to resolve. Jest therefore runs the tests as ES modules, which needs
+ * `--experimental-vm-modules` (see the `test` script) and ts-jest emitting ESM.
+ */
 module.exports = {
   clearMocks: true,
+  extensionsToTreatAsEsm: ['.ts'],
   moduleFileExtensions: ['js', 'ts'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.ts$': 'ts-jest'
+    '^.+\\.ts$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }]
   },
   verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "format-check": "prettier --check **/*.ts",
         "lint": "eslint src/**/*.ts",
         "typecheck": "tsc --noEmit",
-        "test": "jest",
+        "test": "NODE_OPTIONS=--experimental-vm-modules jest",
         "all": "npm run format && npm run lint && npm run typecheck && npm run build"
     },
     "keywords": [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,8 +51,8 @@ function coreStub(inputs: Inputs): CoreStub {
  */
 async function runAction(scenario: Scenario): Promise<{
   core: CoreStub;
-  pullsGet: jest.Mock;
   issuesGet: jest.Mock;
+  action: typeof import('./index');
 }> {
   jest.resetModules();
 
@@ -61,19 +61,15 @@ async function runAction(scenario: Scenario): Promise<{
     ...scenario.inputs,
   });
 
-  const read = (): jest.Mock =>
-    scenario.readError
-      ? (jest.fn(async () => {
-          throw scenario.readError;
-        }) as jest.Mock)
-      : (jest.fn(async () => ({ data: scenario.current ?? {} })) as jest.Mock);
-
-  const pullsGet = read();
-  const issuesGet = read();
+  const { readError } = scenario;
+  const issuesGet = readError
+    ? jest.fn(async () => {
+        throw readError;
+      })
+    : jest.fn(async () => ({ data: scenario.current }));
 
   const octokit = {
     rest: {
-      pulls: { get: pullsGet },
       issues: {
         get: issuesGet,
         listComments: jest.fn(async () => ({ data: [] })),
@@ -96,7 +92,7 @@ async function runAction(scenario: Scenario): Promise<{
   const action = await import('./index');
   await action.completed;
 
-  return { core, pullsGet, issuesGet };
+  return { core, issuesGet, action };
 }
 
 /** A pull request as the payload carries it, before any of the metadata below was applied. */
@@ -194,17 +190,16 @@ describe('evaluating the subject as it is now', () => {
     );
   });
 
-  it('reads a pull request from the pulls endpoint and an issue from the issues endpoint', async () => {
-    // `issues.get` serves a pull request too, but does not report `draft`; only the issues
-    // endpoint exists for an issue.
+  it('reads whichever subject the event delivered', async () => {
+    // One endpoint serves both — a pull request is an issue — so the read does not have to
+    // know which kind of subject it was handed.
     const asPull = await runAction({
       payload: { pull_request: PULL_REQUEST },
       current: PULL_REQUEST,
     });
-    expect(asPull.pullsGet).toHaveBeenCalledWith(
-      expect.objectContaining({ pull_number: 12739 }),
+    expect(asPull.issuesGet).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 12739 }),
     );
-    expect(asPull.issuesGet).not.toHaveBeenCalled();
 
     const asIssue = await runAction({
       payload: { issue: { ...PULL_REQUEST, number: 12805 } },
@@ -213,7 +208,6 @@ describe('evaluating the subject as it is now', () => {
     expect(asIssue.issuesGet).toHaveBeenCalledWith(
       expect.objectContaining({ issue_number: 12805 }),
     );
-    expect(asIssue.pullsGet).not.toHaveBeenCalled();
   });
 });
 
@@ -256,40 +250,71 @@ describe('when the subject cannot be read', () => {
   });
 });
 
-describe('bounding what is read', () => {
-  it('applies the content limits to API-read state, not only to the payload', async () => {
-    const { applySubjectState, sanitizeSubject } = await runAction({
+describe('applying what was read', () => {
+  it('bounds API-read state, not only the payload', async () => {
+    const { action } = await runAction({
       payload: { pull_request: PULL_REQUEST },
       current: PULL_REQUEST,
-    }).then(() => import('./index'));
+    });
 
-    const subject: Parameters<typeof applySubjectState>[0] = {
+    const subject: Parameters<typeof action.applySubjectState>[0] = {
       title: 'the payload title',
     };
-    applySubjectState(subject, {
+    action.applySubjectState(subject, {
       title: 'a'.repeat(600),
       body: 'b'.repeat(70_000),
       labels: Array.from({ length: 150 }, (_, i) => ({ name: `label-${i}` })),
     });
-    sanitizeSubject(subject);
 
     expect(subject.title).toHaveLength(500);
     expect(subject.body).toHaveLength(65_536);
     expect(subject.labels).toHaveLength(100);
   });
 
-  it('clears a milestone that is no longer set', async () => {
-    const { applySubjectState } = await runAction({
+  it('drops a label the response reports without a name', async () => {
+    const { action } = await runAction({
       payload: { pull_request: PULL_REQUEST },
       current: PULL_REQUEST,
-    }).then(() => import('./index'));
+    });
 
-    const subject: Parameters<typeof applySubjectState>[0] = {
+    const subject: Parameters<typeof action.applySubjectState>[0] = {
+      title: 'a pull request',
+    };
+    action.applySubjectState(subject, { labels: [{}, { name: 'kind/bug' }] });
+
+    expect(subject.labels).toEqual([{ name: 'kind/bug' }]);
+  });
+
+  it('clears a milestone that is no longer set', async () => {
+    const { action } = await runAction({
+      payload: { pull_request: PULL_REQUEST },
+      current: PULL_REQUEST,
+    });
+
+    const subject: Parameters<typeof action.applySubjectState>[0] = {
       title: 'a pull request',
       milestone: { title: 'v1.10.0', number: 4 },
     };
-    applySubjectState(subject, { title: 'a pull request', milestone: null });
+    action.applySubjectState(subject, { milestone: null });
 
     expect(subject.milestone).toBeUndefined();
+  });
+
+  it('leaves a field the response does not carry alone', async () => {
+    // An omitted field is not the same as one reported unset: a response that says nothing
+    // about the draft state must not be read as "not a draft".
+    const { action } = await runAction({
+      payload: { pull_request: PULL_REQUEST },
+      current: PULL_REQUEST,
+    });
+
+    const subject: Parameters<typeof action.applySubjectState>[0] = {
+      title: 'the payload title',
+      draft: true,
+    };
+    action.applySubjectState(subject, { labels: [] });
+
+    expect(subject.draft).toBe(true);
+    expect(subject.title).toBe('the payload title');
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,295 @@
+/**
+ * The checks have to describe the subject as it is when they run, not as the event payload
+ * froze it. Re-running a workflow replays the original payload, so a gate reading mutable
+ * metadata reproduces its old verdict instead of observing the change that discharged it.
+ *
+ * Every case here loads the action the way the runner does — the pass starts on import — with
+ * the payload and the API deliberately disagreeing about the subject.
+ */
+
+import { jest } from '@jest/globals';
+
+type Inputs = Record<string, string>;
+
+interface Scenario {
+  inputs?: Inputs;
+  /** The event payload, as frozen when the run was created. */
+  payload: Record<string, unknown>;
+  /** What the API reports for the subject now. */
+  current?: Record<string, unknown>;
+  /** Set to make both read endpoints reject, standing in for an API outage. */
+  readError?: Error;
+  /** Omit the token, leaving the action with no way to read the subject. */
+  withoutToken?: boolean;
+}
+
+interface CoreStub {
+  getInput: jest.Mock<(name: string) => string>;
+  info: jest.Mock<(message: string) => void>;
+  warning: jest.Mock<(message: string) => void>;
+  error: jest.Mock<(message: string) => void>;
+  setFailed: jest.Mock<(message: string) => void>;
+  setSecret: jest.Mock<(secret: string) => void>;
+}
+
+function coreStub(inputs: Inputs): CoreStub {
+  return {
+    getInput: jest.fn((name: string) => inputs[name] ?? ''),
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    setFailed: jest.fn(),
+    setSecret: jest.fn(),
+  };
+}
+
+/**
+ * Loads a fresh copy of the action against the scenario's mocks and waits for its pass.
+ *
+ * The module registry is reset for each load: the action collects its verdict in module-level
+ * state, so a shared instance would carry one case's errors into the next.
+ */
+async function runAction(scenario: Scenario): Promise<{
+  core: CoreStub;
+  pullsGet: jest.Mock;
+  issuesGet: jest.Mock;
+}> {
+  jest.resetModules();
+
+  const core = coreStub({
+    ...(scenario.withoutToken ? {} : { github_token: 'a-token' }),
+    ...scenario.inputs,
+  });
+
+  const read = (): jest.Mock =>
+    scenario.readError
+      ? (jest.fn(async () => {
+          throw scenario.readError;
+        }) as jest.Mock)
+      : (jest.fn(async () => ({ data: scenario.current ?? {} })) as jest.Mock);
+
+  const pullsGet = read();
+  const issuesGet = read();
+
+  const octokit = {
+    rest: {
+      pulls: { get: pullsGet },
+      issues: {
+        get: issuesGet,
+        listComments: jest.fn(async () => ({ data: [] })),
+        createComment: jest.fn(async () => ({ data: {} })),
+        updateComment: jest.fn(async () => ({ data: {} })),
+      },
+    },
+  };
+
+  jest.unstable_mockModule('@actions/core', () => core);
+  jest.unstable_mockModule('@actions/github', () => ({
+    context: {
+      payload: scenario.payload,
+      repo: { owner: 'spiceai', repo: 'spiceai' },
+      actor: 'contributor',
+    },
+    getOctokit: jest.fn(() => octokit),
+  }));
+
+  const action = await import('./index');
+  await action.completed;
+
+  return { core, pullsGet, issuesGet };
+}
+
+/** A pull request as the payload carries it, before any of the metadata below was applied. */
+const PULL_REQUEST = {
+  number: 12739,
+  title: 'fix: a perfectly good pull request',
+  body: 'A description long enough to satisfy the description check.',
+  labels: [],
+  assignees: [],
+  draft: false,
+  user: { login: 'contributor' },
+  head: { ref: 'fix/12726-byoc-lint-debt' },
+  base: { ref: 'trunk' },
+};
+
+describe('evaluating the subject as it is now', () => {
+  it('passes a pull request whose assignee landed after the payload was cut', async () => {
+    // The `opened` payload a re-run replays: `gh pr create` had not yet assigned anyone.
+    const { core } = await runAction({
+      inputs: { require_assignee: 'true' },
+      payload: { pull_request: { ...PULL_REQUEST, assignees: [] } },
+      current: { ...PULL_REQUEST, assignees: [{ login: 'claudespice' }] },
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('fails a pull request whose assignee has since been removed', async () => {
+    // The mirror of the case above. Without it, an implementation that only ever added to the
+    // payload would pass both — read state has to replace what the payload said, not merge with it.
+    const { core } = await runAction({
+      inputs: { require_assignee: 'true' },
+      payload: {
+        pull_request: {
+          ...PULL_REQUEST,
+          assignees: [{ login: 'claudespice' }],
+        },
+      },
+      current: { ...PULL_REQUEST, assignees: [] },
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('At least one assignee is required'),
+    );
+  });
+
+  it('reads the labels the pull request carries now, in either shape', async () => {
+    // The issues endpoint can report a label as a bare string. Left unhandled it has no `name`,
+    // so a label plainly applied reads as missing.
+    const { core } = await runAction({
+      inputs: { required_label_prefixes: 'kind/,area/' },
+      payload: { pull_request: { ...PULL_REQUEST, labels: [] } },
+      current: {
+        ...PULL_REQUEST,
+        labels: ['kind/bug', { name: 'area/cayenne' }],
+      },
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('fails when a required label has since been removed', async () => {
+    const { core } = await runAction({
+      inputs: { required_label_prefixes: 'kind/' },
+      payload: {
+        pull_request: { ...PULL_REQUEST, labels: [{ name: 'kind/bug' }] },
+      },
+      current: { ...PULL_REQUEST, labels: [] },
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('kind/'),
+    );
+  });
+
+  it('reads the draft state the pull request is in now', async () => {
+    const { core } = await runAction({
+      inputs: { enforce_draft: 'true' },
+      payload: { pull_request: { ...PULL_REQUEST, draft: true } },
+      current: { ...PULL_REQUEST, draft: false },
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it('fails a pull request returned to draft after the payload was cut', async () => {
+    const { core } = await runAction({
+      inputs: { enforce_draft: 'true' },
+      payload: { pull_request: { ...PULL_REQUEST, draft: false } },
+      current: { ...PULL_REQUEST, draft: true },
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('Draft pull requests are not allowed'),
+    );
+  });
+
+  it('reads a pull request from the pulls endpoint and an issue from the issues endpoint', async () => {
+    // `issues.get` serves a pull request too, but does not report `draft`; only the issues
+    // endpoint exists for an issue.
+    const asPull = await runAction({
+      payload: { pull_request: PULL_REQUEST },
+      current: PULL_REQUEST,
+    });
+    expect(asPull.pullsGet).toHaveBeenCalledWith(
+      expect.objectContaining({ pull_number: 12739 }),
+    );
+    expect(asPull.issuesGet).not.toHaveBeenCalled();
+
+    const asIssue = await runAction({
+      payload: { issue: { ...PULL_REQUEST, number: 12805 } },
+      current: { ...PULL_REQUEST, number: 12805 },
+    });
+    expect(asIssue.issuesGet).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 12805 }),
+    );
+    expect(asIssue.pullsGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('when the subject cannot be read', () => {
+  it('falls back to the payload rather than failing the check', async () => {
+    // Failing here would mint exactly the false red this read exists to remove.
+    const { core } = await runAction({
+      inputs: { require_assignee: 'true' },
+      payload: {
+        pull_request: {
+          ...PULL_REQUEST,
+          assignees: [{ login: 'claudespice' }],
+        },
+      },
+      readError: new Error('API rate limit exceeded'),
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Falling back to the event payload'),
+    );
+  });
+
+  it('says so when there is no token to read it with', async () => {
+    const { core } = await runAction({
+      inputs: { require_assignee: 'true' },
+      payload: {
+        pull_request: {
+          ...PULL_REQUEST,
+          assignees: [{ login: 'claudespice' }],
+        },
+      },
+      withoutToken: true,
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('No GitHub token provided'),
+    );
+  });
+});
+
+describe('bounding what is read', () => {
+  it('applies the content limits to API-read state, not only to the payload', async () => {
+    const { applySubjectState, sanitizeSubject } = await runAction({
+      payload: { pull_request: PULL_REQUEST },
+      current: PULL_REQUEST,
+    }).then(() => import('./index'));
+
+    const subject: Parameters<typeof applySubjectState>[0] = {
+      title: 'the payload title',
+    };
+    applySubjectState(subject, {
+      title: 'a'.repeat(600),
+      body: 'b'.repeat(70_000),
+      labels: Array.from({ length: 150 }, (_, i) => ({ name: `label-${i}` })),
+    });
+    sanitizeSubject(subject);
+
+    expect(subject.title).toHaveLength(500);
+    expect(subject.body).toHaveLength(65_536);
+    expect(subject.labels).toHaveLength(100);
+  });
+
+  it('clears a milestone that is no longer set', async () => {
+    const { applySubjectState } = await runAction({
+      payload: { pull_request: PULL_REQUEST },
+      current: PULL_REQUEST,
+    }).then(() => import('./index'));
+
+    const subject: Parameters<typeof applySubjectState>[0] = {
+      title: 'a pull request',
+      milestone: { title: 'v1.10.0', number: 4 },
+    };
+    applySubjectState(subject, { title: 'a pull request', milestone: null });
+
+    expect(subject.milestone).toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,24 @@ interface ContentObject {
   base?: { ref: string };
 }
 
+/**
+ * The subject fields a check can see change under it. Everything else `ContentObject` carries —
+ * the number, the author, the head and base refs — is fixed for the life of the pull request,
+ * so the payload remains a good enough source for those.
+ *
+ * Typed loosely because it is filled from two endpoints that disagree on shape: the issues
+ * endpoint can report a label as a bare string, and both report `null` where the payload omits
+ * the field.
+ */
+interface SubjectState {
+  title?: string;
+  body?: string | null;
+  labels?: (string | { name?: string })[];
+  assignees?: { login: string }[] | null;
+  draft?: boolean;
+  milestone?: { title: string; number: number } | null;
+}
+
 interface AutoLabelRule {
   label: string;
   paths: string[];
@@ -123,6 +141,23 @@ function sanitizeString(input: string | undefined, maxLength: number): string {
 }
 
 /**
+ * Bounds the fields an outside contributor controls, so extremely long content cannot be used
+ * to exhaust this job or the comment it posts.
+ *
+ * Applied after every read of the subject rather than once at the top, because the state the
+ * checks evaluate is written from more than one source — the event payload, and the API reads
+ * that supersede it — and a limit only one of those paths honours is not a limit.
+ */
+function sanitizeSubject(subject: ContentObject): void {
+  subject.title = sanitizeString(subject.title, MAX_TITLE_LENGTH);
+  subject.body = sanitizeString(subject.body, MAX_BODY_LENGTH);
+
+  if (subject.labels && subject.labels.length > MAX_LABELS_COUNT) {
+    subject.labels = subject.labels.slice(0, MAX_LABELS_COUNT);
+  }
+}
+
+/**
  * Whether the account that triggered this run already has write access.
  *
  * The AI pass feeds attacker-controllable text — title, description, branch, filenames —
@@ -195,6 +230,86 @@ async function senderCanWrite(
   return false;
 }
 
+/**
+ * Reads the subject's mutable metadata from the API instead of trusting the event payload.
+ *
+ * The payload is a snapshot frozen when the run was created, and re-running a workflow replays
+ * that same snapshot. Every check below reads mutable metadata — labels, assignees, title,
+ * description, draft state, milestone — so a re-run reports the pull request as it was at event
+ * time. A verdict can then never observe the change that discharged it: the re-run reproduces
+ * the original failure, and because its check-run is the newest one on the commit, that stale
+ * failure outranks the success that already followed the fix. Checks that read commit content
+ * re-run correctly, which is why this bites metadata gates specifically.
+ *
+ * The same read narrows the race at `opened`, where an assignee or label applied moments after
+ * the pull request was created is absent from the payload but present by the time this job runs.
+ *
+ * Returns `null` when the subject cannot be read, leaving the caller on the payload: a gate that
+ * failed because the API blipped would be the same class of false red this exists to remove.
+ */
+async function fetchSubjectState(
+  octokit: ReturnType<typeof github.getOctokit>,
+  subjectNumber: number,
+  isIssue: boolean,
+): Promise<SubjectState | null> {
+  try {
+    // A pull request is an issue, so `issues.get` serves both — but it does not report
+    // `draft`, and issues have no pull-request endpoint. Each subject is read from the
+    // endpoint that describes all of it.
+    const { data } = isIssue
+      ? await octokit.rest.issues.get({
+          ...github.context.repo,
+          issue_number: subjectNumber,
+        })
+      : await octokit.rest.pulls.get({
+          ...github.context.repo,
+          pull_number: subjectNumber,
+        });
+
+    return data as SubjectState;
+  } catch (error) {
+    core.warning(
+      `Could not read #${subjectNumber} from the API ` +
+        `(${error instanceof Error ? error.message : 'unknown error'}). Falling back to the ` +
+        'event payload, which is a snapshot from when this run was created.',
+    );
+    return null;
+  }
+}
+
+/** Normalizes the label shapes the two endpoints and the payload disagree on. */
+function normalizeLabels(labels: SubjectState['labels']): Label[] {
+  return (labels ?? []).map((label) =>
+    typeof label === 'string' ? { name: label } : { name: label.name ?? '' },
+  );
+}
+
+/**
+ * Writes read state onto the subject the checks evaluate.
+ *
+ * Absent fields are written as absent rather than skipped: a label or assignee removed since the
+ * payload was cut has to disappear from what is evaluated, or the read would only ever be able to
+ * add to a stale snapshot.
+ */
+function applySubjectState(subject: ContentObject, state: SubjectState): void {
+  if (typeof state.title === 'string') {
+    subject.title = state.title;
+  }
+  subject.body = state.body ?? '';
+  subject.labels = normalizeLabels(state.labels);
+  subject.assignees = (state.assignees ?? []).map(({ login }) => ({ login }));
+  subject.draft = state.draft === true;
+
+  if (state.milestone) {
+    subject.milestone = {
+      title: state.milestone.title,
+      number: state.milestone.number,
+    };
+  } else {
+    delete subject.milestone;
+  }
+}
+
 async function run(): Promise<void> {
   try {
     // Accept either a pull request or an issue. Everything below except the
@@ -213,17 +328,28 @@ async function run(): Promise<void> {
       return;
     }
 
-    // Sanitize inputs to prevent potential issues with extremely long content
-    pullRequest.title = sanitizeString(pullRequest.title, MAX_TITLE_LENGTH);
-    pullRequest.body = sanitizeString(pullRequest.body, MAX_BODY_LENGTH);
-
-    // Limit labels to prevent abuse
-    if (pullRequest.labels && pullRequest.labels.length > MAX_LABELS_COUNT) {
-      pullRequest.labels = pullRequest.labels.slice(0, MAX_LABELS_COUNT);
-    }
-
     const token = core.getInput('github_token');
     const octokit = token ? github.getOctokit(token) : null;
+
+    // Judge the subject as it is now, not as the payload froze it — see `fetchSubjectState`.
+    if (octokit && pullRequest.number) {
+      const current = await fetchSubjectState(
+        octokit,
+        pullRequest.number,
+        isIssue,
+      );
+      if (current) {
+        applySubjectState(pullRequest, current);
+      }
+    } else if (!octokit) {
+      core.warning(
+        'No GitHub token provided, so the checks read the event payload. On a re-run that ' +
+          'payload is a snapshot from when the run was created, and the verdict may describe ' +
+          'a state this pull request has already left.',
+      );
+    }
+
+    sanitizeSubject(pullRequest);
 
     const spiceApiKey = core.getInput('spice_api_key');
     if (spiceApiKey) {
@@ -281,8 +407,8 @@ async function run(): Promise<void> {
       didAutoAssign = await performAutoAssign(octokit, pullRequest);
     }
 
-    // Re-read the PR if we changed anything on it, so the checks below evaluate the
-    // current state. This keyed off `auto_assign` before, which meant an author
+    // Re-read the subject if we changed anything on it, so the checks below evaluate what
+    // this run just wrote. This keyed off `auto_assign` before, which meant an author
     // assignment made via `auto_assign_author` left `pullRequest.assignees` stale and
     // `checkAssignees` failed a PR the action had just assigned. The labelling passes
     // report whether they wrote anything rather than being inferred from
@@ -290,14 +416,15 @@ async function run(): Promise<void> {
     // removed a label would otherwise leave the checks judging the deleted label.
     const needsRefresh = labelsChanged || didAutoAssign;
     if (octokit && pullRequest.number && needsRefresh) {
-      // `issues.get` serves both — a PR is an issue — and unlike `pulls.get` it also
-      // works when this action runs on an issue event.
-      const fresh = await octokit.rest.issues.get({
-        ...github.context.repo,
-        issue_number: pullRequest.number,
-      });
-      pullRequest.labels = fresh.data.labels as Label[];
-      pullRequest.assignees = fresh.data.assignees as User[];
+      const refreshed = await fetchSubjectState(
+        octokit,
+        pullRequest.number,
+        isIssue,
+      );
+      if (refreshed) {
+        applySubjectState(pullRequest, refreshed);
+        sanitizeSubject(pullRequest);
+      }
     }
 
     // Run all the quality checks
@@ -1782,4 +1909,13 @@ function checkBranchNaming(pullRequest: ContentObject): void {
   }
 }
 
-run();
+/**
+ * The runner executes this module as the action's entry point, so the pass starts on load.
+ *
+ * Exposed as a promise because a test imports this module rather than executing it, and needs
+ * a way to await the pass it just started. `run` handles its own failures, so this settles
+ * fulfilled whatever the verdict was.
+ */
+export const completed = run();
+
+export { applySubjectState, fetchSubjectState, run, sanitizeSubject };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,21 +36,23 @@ interface ContentObject {
 }
 
 /**
- * The subject fields a check can see change under it. Everything else `ContentObject` carries —
- * the number, the author, the head and base refs — is fixed for the life of the pull request,
- * so the payload remains a good enough source for those.
+ * The subject fields a check can see change under it, as the API reports them.
  *
- * Typed loosely because it is filled from two endpoints that disagree on shape: the issues
- * endpoint can report a label as a bare string, and both report `null` where the payload omits
- * the field.
+ * The rest of what `ContentObject` carries is either fixed for the life of the subject — the
+ * number, the author, the head ref — or read by nothing that gates: the base ref can be
+ * retargeted on an open pull request, but only the AI prompt reads it. Anything added here has
+ * to be re-read; anything added to a check has to be listed here.
+ *
+ * Nullable where the payload merely omits: the endpoint answers `null` for a description that
+ * was cleared or a milestone that was unset.
  */
 interface SubjectState {
   title?: string;
   body?: string | null;
-  labels?: (string | { name?: string })[];
-  assignees?: { login: string }[] | null;
+  labels?: (string | Partial<Label>)[];
+  assignees?: User[] | null;
   draft?: boolean;
-  milestone?: { title: string; number: number } | null;
+  milestone?: Milestone | null;
 }
 
 interface AutoLabelRule {
@@ -144,17 +146,18 @@ function sanitizeString(input: string | undefined, maxLength: number): string {
  * Bounds the fields an outside contributor controls, so extremely long content cannot be used
  * to exhaust this job or the comment it posts.
  *
- * Applied after every read of the subject rather than once at the top, because the state the
- * checks evaluate is written from more than one source — the event payload, and the API reads
- * that supersede it — and a limit only one of those paths honours is not a limit.
+ * Applied to every source the checks are fed from — the event payload, and the API reads that
+ * supersede it — because a limit only one of those paths honours is not a limit.
  */
 function sanitizeSubject(subject: ContentObject): void {
   subject.title = sanitizeString(subject.title, MAX_TITLE_LENGTH);
   subject.body = sanitizeString(subject.body, MAX_BODY_LENGTH);
-
-  if (subject.labels && subject.labels.length > MAX_LABELS_COUNT) {
-    subject.labels = subject.labels.slice(0, MAX_LABELS_COUNT);
-  }
+  // The same bound the model's answers get: a label list is a label list, whichever untrusted
+  // source produced it. This also drops the empty names `normalizeLabels` yields for a label
+  // object with no `name`, which would otherwise be reported as applied labels.
+  subject.labels = sanitizeLabelList(getLabelNames(subject)).map((name) => ({
+    name,
+  }));
 }
 
 /**
@@ -250,21 +253,15 @@ async function senderCanWrite(
 async function fetchSubjectState(
   octokit: ReturnType<typeof github.getOctokit>,
   subjectNumber: number,
-  isIssue: boolean,
 ): Promise<SubjectState | null> {
   try {
-    // A pull request is an issue, so `issues.get` serves both — but it does not report
-    // `draft`, and issues have no pull-request endpoint. Each subject is read from the
-    // endpoint that describes all of it.
-    const { data } = isIssue
-      ? await octokit.rest.issues.get({
-          ...github.context.repo,
-          issue_number: subjectNumber,
-        })
-      : await octokit.rest.pulls.get({
-          ...github.context.repo,
-          pull_number: subjectNumber,
-        });
+    // `issues.get` serves both — a pull request is an issue — and unlike `pulls.get` it also
+    // works when this action runs on an issue event. It reports every field below for a pull
+    // request too, `draft` included.
+    const { data } = await octokit.rest.issues.get({
+      ...github.context.repo,
+      issue_number: subjectNumber,
+    });
 
     return data as SubjectState;
   } catch (error) {
@@ -285,29 +282,36 @@ function normalizeLabels(labels: SubjectState['labels']): Label[] {
 }
 
 /**
- * Writes read state onto the subject the checks evaluate.
+ * Writes read state onto the subject the checks evaluate, and bounds it.
  *
- * Absent fields are written as absent rather than skipped: a label or assignee removed since the
- * payload was cut has to disappear from what is evaluated, or the read would only ever be able to
- * add to a stale snapshot.
+ * A field the response *carries* is written even when it is empty: a label or assignee removed
+ * since the payload was cut has to disappear from what is evaluated, or a read could only ever
+ * add to a stale snapshot. A field the response omits leaves the payload's value alone, so a
+ * response that does not describe something is never mistaken for one that describes it as
+ * unset.
+ *
+ * Sanitizing here rather than at the call sites is what makes the bound hold on every path that
+ * writes this state, which is the only form of that guarantee worth having.
  */
 function applySubjectState(subject: ContentObject, state: SubjectState): void {
   if (typeof state.title === 'string') {
     subject.title = state.title;
   }
+  if (typeof state.draft === 'boolean') {
+    subject.draft = state.draft;
+  }
   subject.body = state.body ?? '';
   subject.labels = normalizeLabels(state.labels);
-  subject.assignees = (state.assignees ?? []).map(({ login }) => ({ login }));
-  subject.draft = state.draft === true;
+  subject.assignees = state.assignees ?? [];
 
   if (state.milestone) {
-    subject.milestone = {
-      title: state.milestone.title,
-      number: state.milestone.number,
-    };
+    subject.milestone = state.milestone;
   } else {
+    // `exactOptionalPropertyTypes` rules out assigning `undefined` to an optional field.
     delete subject.milestone;
   }
+
+  sanitizeSubject(subject);
 }
 
 async function run(): Promise<void> {
@@ -333,11 +337,7 @@ async function run(): Promise<void> {
 
     // Judge the subject as it is now, not as the payload froze it — see `fetchSubjectState`.
     if (octokit && pullRequest.number) {
-      const current = await fetchSubjectState(
-        octokit,
-        pullRequest.number,
-        isIssue,
-      );
+      const current = await fetchSubjectState(octokit, pullRequest.number);
       if (current) {
         applySubjectState(pullRequest, current);
       }
@@ -345,10 +345,12 @@ async function run(): Promise<void> {
       core.warning(
         'No GitHub token provided, so the checks read the event payload. On a re-run that ' +
           'payload is a snapshot from when the run was created, and the verdict may describe ' +
-          'a state this pull request has already left.',
+          'a state this subject has already left.',
       );
     }
 
+    // Bounds the payload's own content on the paths where no read replaced it. Idempotent, so
+    // it does not need to know whether one did.
     sanitizeSubject(pullRequest);
 
     const spiceApiKey = core.getInput('spice_api_key');
@@ -407,23 +409,16 @@ async function run(): Promise<void> {
       didAutoAssign = await performAutoAssign(octokit, pullRequest);
     }
 
-    // Re-read the subject if we changed anything on it, so the checks below evaluate what
-    // this run just wrote. This keyed off `auto_assign` before, which meant an author
-    // assignment made via `auto_assign_author` left `pullRequest.assignees` stale and
-    // `checkAssignees` failed a PR the action had just assigned. The labelling passes
-    // report whether they wrote anything rather than being inferred from
-    // `autoAppliedLabels`, which only ever records *additions* — an AI pass that just
-    // removed a label would otherwise leave the checks judging the deleted label.
+    // Re-read the subject when this run wrote to it, so the checks judge what it just did
+    // rather than failing a pull request the action has already fixed — an assignee added by
+    // `auto_assign_author`, or a label the AI pass removed. Both passes report whether they
+    // wrote anything: `autoAppliedLabels` records only *additions*, so a pass that removed a
+    // label would otherwise leave the checks judging the deleted one.
     const needsRefresh = labelsChanged || didAutoAssign;
     if (octokit && pullRequest.number && needsRefresh) {
-      const refreshed = await fetchSubjectState(
-        octokit,
-        pullRequest.number,
-        isIssue,
-      );
+      const refreshed = await fetchSubjectState(octokit, pullRequest.number);
       if (refreshed) {
         applySubjectState(pullRequest, refreshed);
-        sanitizeSubject(pullRequest);
       }
     }
 
@@ -1918,4 +1913,4 @@ function checkBranchNaming(pullRequest: ContentObject): void {
  */
 export const completed = run();
 
-export { applySubjectState, fetchSubjectState, run, sanitizeSubject };
+export { applySubjectState };

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,14 @@
+// The build's tsconfig excludes tests, and naming `types` there would put the test runner's
+// globals in scope for `src/index.ts` as well. Tests are typechecked here instead, by ts-jest,
+// and emitted as ES modules because that is how Jest loads this dependency graph — see
+// jest.config.js.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

`enforce-pull-with-spice` is a required status check on `spiceai/spiceai`, and re-running one of
its workflow runs could only ever re-post the original verdict. A `pull_request` /
`pull_request_target` re-run replays the event payload that was frozen when the run was first
created, and every check here reads *mutable* metadata — labels, assignees, title, description,
draft state, milestone — so the re-run reported the pull request as it was then.

That makes the re-run a time machine rather than a retry: it reproduces the failure and can never
observe the change that discharged it, and because the re-run's check-run is the newest one on the
commit, the stale `failure` sorts on top of the genuine `success` that already followed the fix. A
required check goes red on a pull request with nothing wrong with it. It is also self-perpetuating
for any automation that sweeps for red required checks and re-runs them — the sweep sees red,
re-runs, gets red. Five stale runs across four pull requests were re-run in one 17-second burst
that way; all four went red on a required check, and each had to be cleared by hand with a
throwaway label toggle.

Checks that read *commit content* — lint, build, test — re-run correctly, which is why the reflex
to re-run a red check is normally right and is wrong exactly here.

**The fix reads the subject from the API when the run starts, and evaluates that.** The payload is
still what says *which* subject the run is about, and what is still trusted for the fields that
cannot change under it.

Two things fall out beyond making a re-run correct:

- **The race at `opened` narrows.** `gh pr create` fires `opened` before the assignee lands, and
  the payload for that event has no assignee — the documented failure this workflow lives with.
  The read happens after the job has started, so an assignee or label applied in between is now
  seen.
- **The action stops acting on stale state.** `performAutoLabeling` and `performAutoAssign` read
  the same object, so on a replayed payload they could re-add a label a human had just removed, or
  re-assign an already-assigned pull request.

When the subject cannot be read — no token, or the API fails — the action warns and falls back to
the payload rather than failing. A gate that reddened on an API blip would be the same class of
false red this removes.

## Changes

- `fetchSubjectState` reads the subject via `issues.get` (which serves pull requests and issues
  alike, `draft` included — measured against the API on both an open and a draft pull request) and
  returns `null` on failure, leaving the caller on the payload.
- `applySubjectState` writes that state onto the subject the checks evaluate. A field the response
  *carries* is written even when empty, so a label or assignee removed since the payload was cut
  disappears from what is judged; a field the response *omits* leaves the payload's value alone, so
  "not described" is never read as "unset".
- `sanitizeSubject` bounds title, description and labels, and is applied on every path that writes
  the state rather than once at the top — label names now go through `sanitizeLabelList`, the same
  helper the model's answers already get.
- The post-mutation refresh, which previously did its own inline `issues.get` and bypassed the
  label bound, now goes through the same two functions.
- README: a short section documenting that re-running the check re-evaluates current state, what
  token it needs, and what happens without one.
- `npm test` runs in CI. Jest was configured but had never run a test: the action's dependencies
  (`@actions/core`, `@actions/github`, `ai`) publish ESM only with no `require` condition, so the
  CJS runner could not resolve them. It now runs the tests as ES modules.

Deferred, with the reasoning recorded: spiceai/pulls-with-spice-action#29 — the subject is still
assembled by mutation, so a future check reading `base` (which *can* be retargeted) would be stale;
`senderCanWrite` and `postReportToPullRequest` both route around the resolved subject; and the
module-level accumulators are what force the entry point to expose its pass as a promise.

## Test plan

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 13 tests, all passing (the first tests in this repository)
- `npm run build` plus the release workflow's own bundle check (`node dist/index.js` still rejects
  an empty payload) — passing
- `npx prettier --check "src/**/*.ts"` — clean

The tests drive `run` the way the runner does, with the payload and the API deliberately
disagreeing. Each was checked by neutering the fix and confirming the right tests fail:

| neuter | fails |
|---|---|
| never read the subject live | 8 — every case whose payload and API disagree |
| merge read state instead of replacing it | 2 — the "assignee removed" and "label removed" cases |
| drop the sanitize from the state write | 2 — the bounding and empty-label-name cases |

Both directions are covered deliberately: a fix that only ever *added* to the payload would pass
"assignee landed after the payload was cut" while still failing to notice one that was removed.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits"; the
  `grok` companion is not installed on this host, so no cross-model engine was available. Receipt:
  `engine=none exit=1`, head `8aed58f`. The angles were run by hand instead, and two changed the
  diff: whether removing a field's read turns a loud failure into a quiet wrong answer (it does for
  an omitted `draft`, hence taking scalars only when reported), and whether the endpoint dispatch
  I had written was justified — it was not, and the comment justifying it was factually wrong.
- `/security-review`: **skipped** — it scopes itself to the session's working directory, which is a
  different repository from the one this diff lives in; it echoed an empty diff back, so a pass
  from it would have attested nothing. Hand-audited instead: the new reads take the repository from
  the runner context and the number as a typed parameter, so nothing is interpolated into a path;
  label names reaching the PR comment are now bounded by the same helper as the model's; the warning
  quotes `error.message`, matching the existing octokit catch, and no new secret reaches a log. The
  read needs no permission the job did not already hold, and a token without it degrades to the
  payload rather than failing open on a security decision — this gate is a quality gate, not authz.
- `/simplify`: ran, 4 angles. Applied: reuse the existing `Label`/`User`/`Milestone` types instead
  of restating them; drop an identity `.map` and a field-by-field milestone copy; fold the sanitize
  into the state write so the bound is enforced by the function rather than by two call sites
  remembering to pair them; reuse `sanitizeLabelList`; drop a warning branch for an unreachable
  payload shape; remove two exports with no consumer; trim comments that described how the code
  used to work. Skipped: overlapping the read with `getChangedFiles` via `Promise.all` (~100–300ms
  on a job that already pays `npm ci` and an LLM call, and it entangles two independent concerns),
  and the structural items now filed as spiceai/pulls-with-spice-action#29.

Fixes spiceai/spiceai#12805

## Checklist

- [x] Tests added covering the reported failure and its mirror direction
- [x] Each test verified to fail when the fix is neutered
- [x] Lint, typecheck, build, bundle check and tests green locally
- [x] Behaviour documented in the README
- [x] Deferred findings filed rather than dropped